### PR TITLE
Mac address header support for BYOS

### DIFF
--- a/trmnl.koplugin/main.lua
+++ b/trmnl.koplugin/main.lua
@@ -1101,7 +1101,7 @@ function TrmnlDisplay:showConfigDialog()
                 input_type = "number",
             },
             {
-                text = self.settings.mac_header_name or "MAC address",
+                text = self.settings.mac_header_name or "ID",
                 hint = _("MAC address header name (e.g. ID)"),
                 input_type = "string",
             },


### PR DESCRIPTION
Fixes: https://github.com/usetrmnl/trmnl-koreader/issues/7

- Adds mac address header support for BYOS auth.
- Attempts to auto-detect the Mac address, but can be manually overridden in the config menu.


(the auto detect is unavailable on the mac koreader emulator but it works on a kindle)
<img width="849" height="326" alt="image" src="https://github.com/user-attachments/assets/972332f5-3e5a-4ec0-8557-8ef110328dd8" />
